### PR TITLE
simple fix of register buffer memory leakage during ddp training

### DIFF
--- a/native_sparse_attention/module/rope.py
+++ b/native_sparse_attention/module/rope.py
@@ -70,7 +70,7 @@ class RotaryEmbedding(nn.Module):
     cos = None
     sin = None
 
-    def __init__(self, config: RopeConfig, device="cuda"):
+    def __init__(self, config: RopeConfig, device=torch.device(torch.cuda.current_device())):
         super().__init__()
         # BC: "rope_type" was originally "type"
         if hasattr(config, "rope_scaling") and config.rope_scaling is not None:


### PR DESCRIPTION
during ddp training, the default 'cuda' will result in register_buffer being assigned to wrong device:
[Rank 2]   Module: 'model.layers.25.self_attn.rope', Buffer: 'inv_freq', Device: cuda:0

this is a simple fix so that the users don't need to take care about the rope device during implementation of the code